### PR TITLE
Refactor to Manifest V3

### DIFF
--- a/src/changelog.js
+++ b/src/changelog.js
@@ -1,3 +1,5 @@
+import { getWebstoreChangelog } from './utils';
+
 var changelog = document.getElementById('changelog');
 var message = document.getElementById('message');
 var source = document.getElementById('source');

--- a/src/dev.js
+++ b/src/dev.js
@@ -1,11 +1,12 @@
+import { saveCurrentExtensionVersion } from './utils.js';
+
 // This is only for me when I play with it during development.
-chrome.management.getSelf(function(extension) {
+chrome.management.getSelf(async function(extension) {
   if (extension.installType === 'development') {
-    localStorage.eignhdfgaldabilaaegmdfbajngjmoke = '0';
-    localStorage.gbchcmhmhahfdphkhkmpfmihenigjmpp = '0';
-    localStorage.hfhhnacclhffhdffklopdkcgdhifgngh = '0';
-    localStorage.knmdbhdejcjgpahocbnbbekpaehgghnk = '0';
-    localStorage.bebigdkelppomhhjaaianniiifjbgocn = '0';
-    localStorage.eignhdfgaldabilaaegmdfbajngjmoke = '0';
+    await saveCurrentExtensionVersion('eignhdfgaldabilaaegmdfbajngjmoke', '0');
+    await saveCurrentExtensionVersion('gbchcmhmhahfdphkhkmpfmihenigjmpp', '0');
+    await saveCurrentExtensionVersion('hfhhnacclhffhdffklopdkcgdhifgngh', '0');
+    await saveCurrentExtensionVersion('knmdbhdejcjgpahocbnbbekpaehgghnk', '0');
+    await saveCurrentExtensionVersion('bebigdkelppomhhjaaianniiifjbgocn', '0');
   }
 });

--- a/src/management.js
+++ b/src/management.js
@@ -1,3 +1,6 @@
+import { getNotificationId, showExtensionUpdateNotification, closeExtensionNotifications } from './notifications.js';
+import { DEFAULT_OPTIONS, getCurrentExtensionVersion, removeCurrentExtensionVersion, saveCurrentExtensionVersion } from './utils.js';
+
 // Helper function which enables an extension.
 function setEnabledExtension(extension, enabled, callback) {
   chrome.management.setEnabled(extension.id, enabled, function() {
@@ -7,7 +10,7 @@ function setEnabledExtension(extension, enabled, callback) {
 }
 
 // Helper function which uninstalls an extension.
-function uninstallExtension(extension, callback) {
+export function uninstallExtension(extension, callback) {
   chrome.management.uninstall(extension.id, function(e) {
     if (!chrome.runtime.lastError) {
       callback(extension);
@@ -16,11 +19,11 @@ function uninstallExtension(extension, callback) {
 }
 
 // Check if the extension has been updated.
-function checkExtensionVersion(extension) {
+export async function checkExtensionVersion(extension) {
   // Ignore extensions in development (except us).
   if (extension.installType !== 'development' || extension.id === chrome.runtime.id) {
     // Show a notification if the extension version has changed.
-    var currentVersion = localStorage[extension.id];
+    var currentVersion = await getCurrentExtensionVersion(extension.id);
     if (currentVersion && (currentVersion !== extension.version)) {
       // And if the user hasn't already seen this notification.
       var notificationId = getNotificationId(extension);
@@ -40,12 +43,12 @@ function checkExtensionVersion(extension) {
       });
     }
     // Store new version of this extension.
-    localStorage[extension.id] = extension.version;
+    await saveCurrentExtensionVersion(extension.id, extension.version);
   }
 }
 
 // Clean stored data when extension is uninstalled.
-function onExtensionUninstalled(extensionId) {
+export async function onExtensionUninstalled(extensionId) {
   var storageAreas = ['local', 'sync'];
   storageAreas.forEach(function(storageArea) {
     chrome.storage[storageArea].get(null, function(data) {
@@ -57,38 +60,34 @@ function onExtensionUninstalled(extensionId) {
     });
   });
   // Clean extension info.
-  localStorage.removeItem(extensionId);
+  await removeCurrentExtensionVersion(extensionId);
 }
 
 // Dismiss extension notifications when extension is disabled.
-function onExtensionDisabled(extension) {
+export function onExtensionDisabled(extension) {
   closeExtensionNotifications(extension.id);
 }
 
-// At startup...
-chrome.management.getAll(function(extensions) {
-  // Check and save all installed extensions once.
-  extensions.forEach(function(extension) {
-    checkExtensionVersion(extension);
-  });
-  // Clean storage.
-  chrome.management.getAll(function(results) {
-    var extensions = results.map(function(e) { return e.id });
-    var keysToRemove = [];
-    chrome.storage.sync.get(null, function(results) {
-      Object.keys(results).forEach(function(key) {
-        // Keep extensions storage history from extensions that are still there
-        // and remove the other ones.
-        if (key.length > 32 && extensions.indexOf(key.slice(0, 32)) < 0) {
-          keysToRemove.push(key);
-        }
+export function onStartup() {
+  chrome.management.getAll(async function(extensions) {
+    // Check and save all installed extensions once.
+    await Promise.all(extensions.map(function(extension) {
+      return checkExtensionVersion(extension);
+    }));
+    // Clean storage.
+    chrome.management.getAll(function(results) {
+      var extensions = results.map(function(e) { return e.id });
+      var keysToRemove = [];
+      chrome.storage.sync.get(null, function(results) {
+        Object.keys(results).forEach(function(key) {
+          // Keep extensions storage history from extensions that are still there
+          // and remove the other ones.
+          if (key.length > 32 && extensions.indexOf(key.slice(0, 32)) < 0) {
+            keysToRemove.push(key);
+          }
+        });
+        chrome.storage.sync.remove(keysToRemove);
       });
-      chrome.storage.sync.remove(keysToRemove);
     });
   });
-});
-
-// Register all listeners.
-chrome.management.onInstalled.addListener(checkExtensionVersion);
-chrome.management.onUninstalled.addListener(onExtensionUninstalled);
-chrome.management.onDisabled.addListener(onExtensionDisabled);
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
    "background": {
-      "persistent": false,
-      "scripts": [ "utils.js", "notifications.js", "management.js" ]
+      "service_worker": "service_worker.js",
+      "type": "module"
    },
    "default_locale": "en",
    "description": "__MSG_extDescription__",
@@ -10,15 +10,13 @@
       "48": "images/48.png",
       "128": "images/128.png"
    },
-   "manifest_version": 2,
-   "minimum_chrome_version": "50.0.2661.50",
+   "manifest_version": 3,
    "name": "__MSG_extName__",
-   "optional_permissions": [ "https://chrome.google.com/*" ],
+   "optional_host_permissions": [ "https://chrome.google.com/*" ],
    "options_ui": {
-     "page": "options.html",
-     "chrome_style": true
+     "page": "options.html"
    },
-   "permissions": [ "alarms", "management", "notifications", "storage" ],
+   "permissions": [ "alarms", "management", "notifications", "offscreen", "storage" ],
    "version": "3.5",
    "version_name": "3.5"
 }

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -1,6 +1,12 @@
-var iconSize = 48 * devicePixelRatio;
-var notificationSize = 80 * devicePixelRatio;
-var buttonSize = 16 * devicePixelRatio;
+import { uninstallExtension } from './management.js';
+import { setUpOffscreenDocument } from './offscreen_utils.js';
+import { DEFAULT_OPTIONS, NO_PERMISSIONS_GRANTED, getWebstoreChangelog, MESSAGES, TARGETS } from './utils.js';
+
+// Hardcoded since we don't have access to window.devicePixelRatio from
+// a service worker.
+// TODO(avm99963): move this calculation to the offscreen document.
+const devicePixelRatio = 2;
+const buttonSize = 16 * devicePixelRatio;
 
 // Helper function which returns a basic notification options object.
 function getNotificationOptions(extensionId) {
@@ -8,7 +14,7 @@ function getNotificationOptions(extensionId) {
     type: 'basic',
     priority: 2,
     requireInteraction: true,
-    iconUrl: 'chrome://extension-icon/'+ extensionId +'/'+ iconSize +'/1'
+    extensionId,
   };
 }
 
@@ -17,39 +23,31 @@ function getButtonIconUrl(name) {
   return chrome.runtime.getURL('/images/' + name + '_' + buttonSize + '.png');
 }
 
-// Helper function which returns extension Icon Data Url.
-function getExtensionIconDataUrl(url, callback) {
-  var icon = new Image();
-  icon.onload = function() {
-    var canvas = document.createElement('canvas');
-    canvas.width = canvas.height = notificationSize;
-
-    var context = canvas.getContext('2d');
-
-    var iconLeft = iconTop = (notificationSize - iconSize) / 2;
-    context.drawImage(icon, iconLeft, iconTop);
-    callback(canvas.toDataURL('image/png'));
-  }
-  icon.src = url;
+// Helper function which displays a notification.
+async function showNotification(notificationId, options) {
+  await setUpOffscreenDocument();
+  chrome.runtime.sendMessage({
+    type: MESSAGES.GENERATE_ICON_AND_SEND_NOTIFICATION,
+    target: TARGETS.OFFSCREEN,
+    data: { notificationId, options },
+  });
 }
 
-// Helper function which displays a notification.
-function showNotification(notificationId, options) {
-  getExtensionIconDataUrl(options.iconUrl, function(iconDataUrl) {
-    options.iconUrl = iconDataUrl;
-    chrome.notifications.create(notificationId, options, function(){
-      chrome.storage.sync.get({autoCloseNotification: DEFAULT_OPTIONS.AUTO_CLOSE_NOTIFICATION}, function(results) {
-        if (results.autoCloseNotification) {
-          // Raises an alarm to close notification after 10s.
-          chrome.alarms.create(notificationId, { when: Date.now() + 10e3 });
-        }
-      });
+// Function called after the extension icon is retrieved in the
+// offscreen document.
+export function sendNotification(notificationId, options) {
+  chrome.notifications.create(notificationId, options, function(){
+    chrome.storage.sync.get({autoCloseNotification: DEFAULT_OPTIONS.AUTO_CLOSE_NOTIFICATION}, function(results) {
+      if (results.autoCloseNotification) {
+        // Raises an alarm to close notification after 10s.
+        chrome.alarms.create(notificationId, { when: Date.now() + 10e3 });
+      }
     });
   });
 }
 
 // Helper function to create notification Id
-function getNotificationId(extension) {
+export function getNotificationId(extension) {
   return extension.id + extension.version;
 }
 
@@ -63,7 +61,7 @@ function setExtensionUpdateNotificationOptions(extension, oldVersion, showChange
   // Make the icon gray and add "Enable" and "Uninstall" buttons if the
   // extension is disabled.
   if (!extension.enabled) {
-    options.iconUrl += '?grayscale=true';
+    options.showGrayScaleIcon = true;
     options.buttons.push({
       title: chrome.i18n.getMessage('enableButtonTitle'),
       iconUrl: getButtonIconUrl('action')
@@ -92,7 +90,7 @@ function setExtensionUpdateNotificationOptions(extension, oldVersion, showChange
 }
 
 // Show a notification when an extension has been updated.
-function showExtensionUpdateNotification(extension, oldVersion) {
+export function showExtensionUpdateNotification(extension, oldVersion) {
   var options;
   chrome.storage.sync.get({showChangelog: DEFAULT_OPTIONS.SHOW_CHANGELOG}, function(results) {
     // Don't show changelog button if user doesn't want it.
@@ -134,7 +132,7 @@ function showExtensionUninstalledNotification(extension) {
 }
 
 // Handle notifications actions on button Click.
-function onNotificationsButtonClicked(notificationId, buttonIndex) {
+export function onNotificationsButtonClicked(notificationId, buttonIndex) {
   var clickedNotification = {};
   clickedNotification[notificationId] = 'clickedByUser';
   chrome.storage.local.set(clickedNotification, function() {
@@ -158,7 +156,7 @@ function onNotificationsButtonClicked(notificationId, buttonIndex) {
 }
 
 // Clear notification if user clicks on it.
-function onNotificationsClicked(notificationId) {
+export function onNotificationsClicked(notificationId) {
   // Open new options page.
   if (notificationId === 'newOptions') {
     chrome.runtime.openOptionsPage();
@@ -171,7 +169,7 @@ function onNotificationsClicked(notificationId) {
 }
 
 // Warn the others that this notification has been closed by the user.
-function onNotificationsClosed(notificationId, closedByUser) {
+export function onNotificationsClosed(notificationId, closedByUser) {
   chrome.storage.local.get(notificationId, function(results) {
     if (closedByUser || results[notificationId] === 'clickedByUser') {
       var closedNotification = {};
@@ -182,7 +180,7 @@ function onNotificationsClosed(notificationId, closedByUser) {
 }
 
 // Close notification if user already closed it on another device.
-function onStorageChanged(changes, area) {
+export function onStorageChanged(changes, area) {
   for (var notificationId in changes) {
     if (changes[notificationId].newValue === 'closedByUser')
       chrome.notifications.clear(notificationId);
@@ -190,11 +188,11 @@ function onStorageChanged(changes, area) {
 }
 
 // Open extensions options page when user clicked on notification settings.
-function onNotificationsShowSettings() {
+export function onNotificationsShowSettings() {
   chrome.runtime.openOptionsPage();
 }
 
-function closeExtensionNotifications(extensionId) {
+export function closeExtensionNotifications(extensionId) {
  chrome.notifications.getAll(function(notificationIds) {
     Object.keys(notificationIds).forEach(function(notificationId) {
       if (notificationId.indexOf(extensionId) === 0) {
@@ -204,7 +202,7 @@ function closeExtensionNotifications(extensionId) {
   });
 }
 
-function onAlarm(alarm) {
+export function onAlarm(alarm) {
   // Show new options notification when alarm is received.
   if (alarm.name === 'newOptions') {
     chrome.storage.sync.get('newOptions', function(results) {
@@ -227,7 +225,7 @@ function onAlarm(alarm) {
   }
 }
 
-function onInstalled(details) {
+export function onInstalled(details) {
   // Display a Welcome notification if this extension is installed for the first time.
   if (details.reason === 'install') {
     var options = getNotificationOptions(chrome.runtime.id);
@@ -240,12 +238,3 @@ function onInstalled(details) {
   // Wait for 30 seconds before prompting user about new options.
   chrome.alarms.create('newOptions', { when: Date.now() + 30e3 });
 }
-
-// Register all listeners.
-chrome.alarms.onAlarm.addListener(onAlarm);
-chrome.notifications.onButtonClicked.addListener(onNotificationsButtonClicked);
-chrome.notifications.onClicked.addListener(onNotificationsClicked);
-chrome.notifications.onClosed.addListener(onNotificationsClosed);
-chrome.notifications.onShowSettings.addListener(onNotificationsShowSettings)
-chrome.storage.onChanged.addListener(onStorageChanged);
-chrome.runtime.onInstalled.addListener(onInstalled);

--- a/src/offscreen.html
+++ b/src/offscreen.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<head>
+  <title>Offscreen document</title>
+<body>
+  <script src="offscreen.js" type="module"></script>

--- a/src/offscreen.js
+++ b/src/offscreen.js
@@ -1,0 +1,55 @@
+import { MESSAGES, TARGETS } from './utils.js';
+
+const iconSize = 48 * window.devicePixelRatio;
+const notificationSize = 80 * window.devicePixelRatio;
+
+chrome.runtime.onMessage.addListener(handleMessage);
+
+function handleMessage(message) {
+  if (message.target !== TARGETS.OFFSCREEN) {
+    return false;
+  }
+
+  switch (message.type) {
+    case MESSAGES.GENERATE_ICON_AND_SEND_NOTIFICATION:
+      generateIconAndSendNotification(message.data.notificationId, message.data.options);
+      break;
+
+    default:
+      console.error(`Received unexpected message in offscreen document: ${message.type}.`);
+      return false;
+  }
+}
+
+async function generateIconAndSendNotification(notificationId, options) {
+  const iconDataUrl = await getExtensionIconDataUrl(options.extensionId, options.showGrayScaleIcon);
+  options.iconUrl = iconDataUrl;
+  options.extensionId = undefined;
+  options.showGrayScaleIcon = undefined;
+  chrome.runtime.sendMessage({
+    type: MESSAGES.SEND_NOTIFICATION,
+    target: TARGETS.SERVICE_WORKER,
+    data: { notificationId, options },
+  });
+}
+
+// Helper function which returns extension Icon Data Url.
+async function getExtensionIconDataUrl(extensionId, showGrayScaleIcon) {
+  return new Promise((resolve) => {
+    const baseUrl = 'chrome://extension-icon/'+ extensionId +'/'+ iconSize +'/1';
+    const url = baseUrl + (showGrayScaleIcon ? '?grayscale=true' : '');
+    const icon = new Image();
+    icon.onload = function() {
+      const canvas = document.createElement('canvas');
+      canvas.width = canvas.height = notificationSize;
+
+      const context = canvas.getContext('2d');
+
+      const iconLeft = (notificationSize - iconSize) / 2;
+      const iconTop = iconLeft;
+      context.drawImage(icon, iconLeft, iconTop);
+      resolve(canvas.toDataURL('image/png'));
+    }
+    icon.src = url;
+  });
+}

--- a/src/offscreen_utils.js
+++ b/src/offscreen_utils.js
@@ -1,0 +1,28 @@
+// Based on https://developer.chrome.com/docs/extensions/reference/api/offscreen#examples
+const OFFSCREEN_DOCUMENT = 'offscreen.html';
+
+let creating = undefined;
+export async function setUpOffscreenDocument() {
+  const offscreenUrl = chrome.runtime.getURL(OFFSCREEN_DOCUMENT);
+  const existingContexts = await chrome.runtime.getContexts({
+    contextTypes: ['OFFSCREEN_DOCUMENT'],
+    documentUrls: [offscreenUrl]
+  });
+
+  if (existingContexts.length > 0) {
+    return;
+  }
+
+  // create offscreen document
+  if (creating) {
+    await creating;
+  } else {
+    creating = chrome.offscreen.createDocument({
+      url: OFFSCREEN_DOCUMENT,
+      reasons: ['DOM_SCRAPING'],
+      justification: 'The extension is retrieving an extension\'s icon to generate a notification icon.',
+    });
+    await creating;
+    creating = undefined;
+  }
+}

--- a/src/options.html
+++ b/src/options.html
@@ -19,7 +19,6 @@
     <input type="checkbox" id="alwaysDisableExtension">
     <span i18-content="alwaysDisableExtension"></span>
   </label>
-  <script src="utils.js"></script>
-  <script src="options.js"></script>
+  <script src="options.js" type="module"></script>
 </body>
 </html>

--- a/src/options.js
+++ b/src/options.js
@@ -1,3 +1,5 @@
+import { DEFAULT_OPTIONS, localize } from './utils.js';
+
 var showChangelogCheckbox = document.querySelector('#showChangelog');
 var autoCloseNotificationCheckbox = document.querySelector('#autoCloseNotification');
 var alwaysDisableExtensionCheckbox = document.querySelector('#alwaysDisableExtension');

--- a/src/service_worker.js
+++ b/src/service_worker.js
@@ -1,0 +1,53 @@
+import './dev.js';
+import {
+  onAlarm,
+  onNotificationsButtonClicked,
+  onNotificationsClicked,
+  onNotificationsClosed,
+  onNotificationsShowSettings,
+  onStorageChanged,
+  onInstalled,
+  sendNotification,
+} from './notifications.js';
+import {
+  checkExtensionVersion,
+  onExtensionUninstalled,
+  onExtensionDisabled,
+  onStartup,
+} from './management.js';
+import { MESSAGES, TARGETS } from './utils.js';
+
+// Notification handlers
+chrome.alarms.onAlarm.addListener(onAlarm);
+chrome.notifications.onButtonClicked.addListener(onNotificationsButtonClicked);
+chrome.notifications.onClicked.addListener(onNotificationsClicked);
+chrome.notifications.onClosed.addListener(onNotificationsClosed);
+chrome.notifications.onShowSettings.addListener(onNotificationsShowSettings);
+chrome.storage.onChanged.addListener(onStorageChanged);
+chrome.runtime.onInstalled.addListener(onInstalled);
+
+// Management handlers
+chrome.management.onInstalled.addListener(checkExtensionVersion);
+chrome.management.onUninstalled.addListener(onExtensionUninstalled);
+chrome.management.onDisabled.addListener(onExtensionDisabled);
+
+// Runtime messages
+chrome.runtime.onMessage.addListener(handleMessage);
+
+function handleMessage(message) {
+  if (message.target !== TARGETS.SERVICE_WORKER) {
+    return false;
+  }
+
+  switch (message.type) {
+    case MESSAGES.SEND_NOTIFICATION:
+      sendNotification(message.data.notificationId, message.data.options);
+      break;
+
+    default:
+      console.error(`Received unexpected message in service worker: ${message.type}.`);
+      return false;
+  }
+}
+
+onStartup();

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,13 +1,24 @@
-var NO_PERMISSIONS_GRANTED = 'NO_PERMISSIONS_GRANTED';
+export const NO_PERMISSIONS_GRANTED = 'NO_PERMISSIONS_GRANTED';
 
-var DEFAULT_OPTIONS = {
+export const DEFAULT_OPTIONS = {
   ALWAYS_DISABLE_EXTENSION: false,
   AUTO_CLOSE_NOTIFICATION: false,
   SHOW_CHANGELOG: true,
 }
 
+export const MESSAGES = {
+  GENERATE_ICON_AND_SEND_NOTIFICATION: 'GENERATE_ICON_AND_SEND_NOTIFICATION',
+  SEND_NOTIFICATION: 'SEND_NOTIFICATION',
+}
+export const TARGETS = {
+  OFFSCREEN: 'OFFSCREEN',
+  SERVICE_WORKER: 'SERVICE_WORKER',
+};
+
+export const EXTENSION_VERSIONS_KEY = '__extensionVersions__';
+
 // Localize all content.
-function localize() {
+export function localize() {
   var elements = document.querySelectorAll('[i18-content]');
   for (var element, i = 0; element = elements[i]; i++) {
     var messageName = element.getAttribute('i18-content');
@@ -16,7 +27,7 @@ function localize() {
 }
 
 // Attempts to get changelog if webstore extension page has one.
-function getWebstoreChangelog(extensionId, successCallback, errorCallback) {
+export function getWebstoreChangelog(extensionId, successCallback, errorCallback) {
   var permissions = { origins: ['https://chrome.google.com/*'] };
   chrome.permissions.contains(permissions, function(result) {
     if (!result) {
@@ -52,4 +63,25 @@ function getWebstoreChangelog(extensionId, successCallback, errorCallback) {
     xhr.onerror = errorCallback;
     xhr.send(null);
   });
+}
+
+export async function getExtensionVersions() {
+  const results = await chrome.storage.local.get(EXTENSION_VERSIONS_KEY);
+  return results[EXTENSION_VERSIONS_KEY] ?? {};
+}
+
+export async function getCurrentExtensionVersion(extensionId) {
+  return (await getExtensionVersions())[extensionId];
+}
+
+export async function saveCurrentExtensionVersion(extensionId, version) {
+  const extensionVersions = await getExtensionVersions();
+  extensionVersions[extensionId] = version;
+  await chrome.storage.local.set({ [EXTENSION_VERSIONS_KEY]: extensionVersions });
+}
+
+export async function removeCurrentExtensionVersion(extensionId) {
+  const extensionVersions = await getExtensionVersions();
+  delete extensionVersions[extensionId];
+  await chrome.storage.local.set({ [EXTENSION_VERSIONS_KEY]: extensionVersions });
 }


### PR DESCRIPTION
This commit refactors the extension to Manifest V3 to maintain compatibility with current versions of Chrome.

It does so by:

- Migrating the background page to a service worker, as required by MV3.
- Saving the current extension versions in the extension's local storage area via the chrome.storage API instead of saving them in the background page's |localStorage|, since the background page is no longer available.
- Generating the notifications details in an off-screen document, since service workers can't fetch other extensions' icons and don't have access to |window.devicePixelRatio|.
- Making all the scripts behave as Javascript modules, so they can export and import code from other files. Before this, the background page included all the scripts, but since service workers must have a single script as the entry point, this lets us continue separating the code into multiple files.
- Refactoring manifest.json with the structure required by V3.